### PR TITLE
Feature/tab title styling

### DIFF
--- a/app/src/main/java/com/example/android/yffandroid/PagerFragment.java
+++ b/app/src/main/java/com/example/android/yffandroid/PagerFragment.java
@@ -1,19 +1,23 @@
 package com.example.android.yffandroid;
 
+import android.graphics.Typeface;
 import android.os.Bundle;
 import android.support.annotation.Nullable;
 import android.support.design.widget.TabLayout;
 import android.support.v4.view.PagerAdapter;
 import android.support.v4.view.ViewPager;
+import android.support.v4.widget.TextViewCompat;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
+import android.widget.TextView;
 
 /**
  * Created by chris on 12/3/17.
  */
 public class PagerFragment extends android.support.v4.app.Fragment {
     private Artist mArtist;
+    private TabLayout mTabLayout;
 
     @Nullable
     @Override
@@ -26,8 +30,27 @@ public class PagerFragment extends android.support.v4.app.Fragment {
 
         TabLayout tabLayout = (TabLayout) rootView.findViewById(R.id.sliding_tabs);
         tabLayout.setupWithViewPager(pager);
+        mTabLayout = tabLayout;
+
+        setTypefaceOnAllTabs();
 
         return rootView;
+    }
+
+    private void setTypefaceOnAllTabs() {
+        Typeface bebasNeue = Typeface.createFromAsset(getContext().getAssets(), "fonts/BebasNeueRegular.otf");
+        ViewGroup vg = (ViewGroup) mTabLayout.getChildAt(0);
+        int tabsCount = vg.getChildCount();
+        for (int j = 0; j < tabsCount; j++) {
+            ViewGroup vgTab = (ViewGroup) vg.getChildAt(j);
+            int tabChildrenCount = vgTab.getChildCount();
+            for (int i = 0; i < tabChildrenCount; i++) {
+                View tabViewChild = vgTab.getChildAt(i);
+                if (tabViewChild instanceof TextView) {
+                    ((TextView) tabViewChild).setTypeface(bebasNeue);
+                }
+            }
+        }
     }
 
     private PagerAdapter buildAdapter() {

--- a/app/src/main/res/layout/pager_fragment.xml
+++ b/app/src/main/res/layout/pager_fragment.xml
@@ -7,6 +7,7 @@
 
     <android.support.design.widget.TabLayout
         android:id="@+id/sliding_tabs"
+        style="@style/ArtistTabLayout"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         app:tabMode="fixed" />

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -7,4 +7,13 @@
         <item name="colorPrimaryDark">@color/colorPrimaryDark</item>
         <item name="colorAccent">@color/colorAccent</item>
     </style>
+
+    <style name="ArtistTabLayout" parent="Widget.Design.TabLayout">
+        <item name="tabIndicatorColor">@color/colorYFFOlive</item>
+        <item name="tabTextAppearance">@style/ArtistTabTextAppearance</item>
+        <item name="android:paddingTop">12sp</item>
+    </style>
+    <style name="ArtistTabTextAppearance" parent="TextAppearance.Design.Tab">
+        <item name="android:textSize">22sp</item>
+    </style>
 </resources>


### PR DESCRIPTION
Adds a bit of padding to the top of the tabs, and sets the indicator color, correct font and size. For some reason, I couldn't figure out how to add padding to the _bottom_ of the tab though; between the title and the indicator.